### PR TITLE
【Fixed】rails generateで不要なファイルが作成されないよう設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,6 @@ module RailsExam3
     config.active_record.default_timezone = :local
     config.load_defaults 5.1
     config.generators do |g|
-      # この二行の記述で自動生成しない設定を作成しています。
       g.assets false
       g.helper false
     end


### PR DESCRIPTION
#1 

・raild generateを実行した際、asset・helperが作成されないようapp/config/applicationを修正